### PR TITLE
tests: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ node_js:
   - "5"
   - "6"
   - "7"
+before_install:
+  - npm i -g npm@latest
+install:
+  - npm ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"
   - "7"
+  - "8"
+  - "9"
 before_install:
   - npm i -g npm@latest
 install:


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable