### PR TITLE
Add hljs class to highlight.js node

### DIFF
--- a/helpers/code.js
+++ b/helpers/code.js
@@ -14,5 +14,5 @@ module.exports = function(language, options) {
 
   var code = hljs.highlight(language, options.fn(this)).value;
 
-  return format('<div class="code-example"><pre><code class="%s">%s</code></pre></div>', language, code);
+  return format('<div class="code-example"><pre><code class="%s hljs">%s</code></pre></div>', language, code);
 }

--- a/helpers/markdown.js
+++ b/helpers/markdown.js
@@ -16,7 +16,7 @@ var marked = require('marked');
      if (typeof language === 'undefined') language = 'html';
 
      var renderedCode = hljs.highlight(language, code).value;
-     var output = `<div class="code-example"><pre><code class="${language}">${renderedCode}</code></pre></div>`;
+     var output = `<div class="code-example"><pre><code class="${language} hljs">${renderedCode}</code></pre></div>`;
 
      return output;
    };

--- a/test/fixtures/helper-code/build/index.html
+++ b/test/fixtures/helper-code/build/index.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <div class="code-example"><pre><code class="css"><span class="hljs-class">.good-design</span> <span class="hljs-rules">{
+    <div class="code-example"><pre><code class="css hljs"><span class="hljs-class">.good-design</span> <span class="hljs-rules">{
       <span class="hljs-rule"><span class="hljs-attribute">font-weight</span>:<span class="hljs-value"> <span class="hljs-number">100</span></span></span>;
       <span class="hljs-rule"><span class="hljs-attribute">color</span>:<span class="hljs-value"> <span class="hljs-hexcolor">#000</span></span></span>;
       <span class="hljs-rule"><span class="hljs-attribute">box-shadow</span>:<span class="hljs-value"> <span class="hljs-number">0</span> -<span class="hljs-number">1px</span> <span class="hljs-number">0</span> <span class="hljs-hexcolor">#fff</span></span></span>;

--- a/test/fixtures/helper-code/expected/index.html
+++ b/test/fixtures/helper-code/expected/index.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <div class="code-example"><pre><code class="css"><span class="hljs-class">.good-design</span> <span class="hljs-rules">{
+    <div class="code-example"><pre><code class="css hljs"><span class="hljs-class">.good-design</span> <span class="hljs-rules">{
       <span class="hljs-rule"><span class="hljs-attribute">font-weight</span>:<span class="hljs-value"> <span class="hljs-number">100</span></span></span>;
       <span class="hljs-rule"><span class="hljs-attribute">color</span>:<span class="hljs-value"> <span class="hljs-hexcolor">#000</span></span></span>;
       <span class="hljs-rule"><span class="hljs-attribute">box-shadow</span>:<span class="hljs-value"> <span class="hljs-number">0</span> -<span class="hljs-number">1px</span> <span class="hljs-number">0</span> <span class="hljs-hexcolor">#fff</span></span></span>;


### PR DESCRIPTION
Relates to: https://github.com/foundation/panini/issues/212

When rendering the highlight.js code, the root class hljs is required. In this PR:
1) Added hljs to helpers/code.js and helpers/markup.js
