### PR TITLE
Add a simple reset function

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,3 +51,6 @@ module.exports.refresh = function() {}
 module.exports.help = function() {
   help();
 }
+module.exports.reset = function() {
+  panini = undefined;
+};


### PR DESCRIPTION
We use `panini` for e-mail testing in a i18n multi product evironment.

During our development we encountered some strange behaviour on a longer runing gulp task. Some templates (same file names, different directories) are picked wrong which may be related to some caching issues.
Our quick fix was this simple function which just cleares the global object and therefore forces the engine to be recreated.

Any other hint or real solution would be realy appreciated :)